### PR TITLE
feat: Lock slides with frosted glass overlay for scrollable lists

### DIFF
--- a/components/most-pushed-slide.tsx
+++ b/components/most-pushed-slide.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image"
 import { StatSlide } from "./stat-slide"
+import { ScrollableList } from "./scrollable-list"
 import type { Video } from "@/lib/types"
 
 function getYouTubeThumbnail(url: string, quality: "maxresdefault" | "mqdefault" = "maxresdefault"): string | null {
@@ -16,65 +17,64 @@ function getYouTubeThumbnail(url: string, quality: "maxresdefault" | "mqdefault"
 
 export function MostPushedSlide({ videos, gradient }: { videos: Video[]; gradient: { from: string; to: string } }) {
   const top = videos[0]
-  const rest = videos.slice(1)
   const thumbnail = top ? getYouTubeThumbnail(top.url) : null
 
   return (
     <StatSlide gradient={gradient} label="YOUTUBE REALLY WANTS YOU TO SEE">
       {top ? (
-        <div className="mt-4 w-full max-w-2xl mx-auto max-h-[80vh] overflow-y-auto">
-          {/* Hero #1 */}
+        <div className="w-full max-w-xl mx-auto flex flex-col items-center">
           <a
             href={top.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="block group mb-6"
+            className="block group mb-2 w-full"
           >
             {thumbnail && (
-              <div className="relative w-full aspect-video rounded-2xl overflow-hidden bg-white/10 mb-4 shadow-2xl group-hover:scale-[1.02] transition-transform duration-300">
+              <div className="relative w-full aspect-video rounded-2xl overflow-hidden bg-white/10 mb-3 shadow-2xl group-hover:scale-[1.02] transition-transform duration-300">
                 <Image src={thumbnail} alt={top.title} fill className="object-cover" unoptimized />
                 <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/10 transition-colors">
-                  <div className="w-16 h-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center group-hover:scale-110 transition-transform">
-                    <svg className="w-7 h-7 text-white ml-1" fill="currentColor" viewBox="0 0 24 24">
+                  <div className="w-14 h-14 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <svg className="w-6 h-6 text-white ml-1" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M8 5v14l11-7z" />
                     </svg>
                   </div>
                 </div>
               </div>
             )}
-            <p className="text-white font-bold text-lg leading-snug mb-1">{top.title}</p>
-            <p className="text-white/50 text-sm">
+            <p className="text-white font-bold text-base leading-snug mb-1 text-center">{top.title}</p>
+            <p className="text-white/50 text-sm text-center">
               Recommended to you <span className="text-white font-bold">{top.timesSeen}×</span>
             </p>
           </a>
 
-          {/* Rest of the list */}
-          {rest.length > 0 && (
-            <div className="space-y-2">
-              {rest.map((v, i) => {
-                const thumb = getYouTubeThumbnail(v.url, "mqdefault")
-                return (
-                  <a
-                    key={v.url}
-                    href={v.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-3 p-3 rounded-xl bg-white/5 hover:bg-white/10 transition-colors"
-                  >
-                    <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 2}</span>
-                    {thumb && (
-                      <div className="relative w-20 h-12 flex-shrink-0 rounded-lg overflow-hidden bg-white/10">
-                        <Image src={thumb} alt={v.title} fill className="object-cover" unoptimized />
+          {videos.length > 1 && (
+            <ScrollableList buttonLabel={`View all ${videos.length} videos`}>
+              <div className="space-y-2">
+                {videos.map((v, i) => {
+                  const thumb = getYouTubeThumbnail(v.url, "mqdefault")
+                  return (
+                    <a
+                      key={v.url}
+                      href={v.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-3 p-3 rounded-xl bg-white/10 hover:bg-white/15 transition-colors"
+                    >
+                      <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 1}</span>
+                      {thumb && (
+                        <div className="relative w-20 h-12 flex-shrink-0 rounded-lg overflow-hidden bg-white/10">
+                          <Image src={thumb} alt={v.title} fill className="object-cover" unoptimized />
+                        </div>
+                      )}
+                      <div className="flex-1 min-w-0 text-left">
+                        <p className="text-sm text-white/90 font-medium line-clamp-2">{v.title}</p>
+                        <p className="text-xs text-white/40 mt-0.5">seen {v.timesSeen}×</p>
                       </div>
-                    )}
-                    <div className="flex-1 min-w-0 text-left">
-                      <p className="text-sm text-white/80 font-medium line-clamp-2">{v.title}</p>
-                      <p className="text-xs text-white/40 mt-0.5">seen {v.timesSeen}×</p>
-                    </div>
-                  </a>
-                )
-              })}
-            </div>
+                    </a>
+                  )
+                })}
+              </div>
+            </ScrollableList>
           )}
         </div>
       ) : (

--- a/components/most-watched-slide.tsx
+++ b/components/most-watched-slide.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image"
 import { StatSlide } from "./stat-slide"
+import { ScrollableList } from "./scrollable-list"
 import type { Video } from "@/lib/types"
 
 function getThumb(url: string): string | null {
@@ -39,34 +40,36 @@ export function MostWatchedSlide({ videos, gradient }: { videos: Video[]; gradie
       subtext={totalSeconds > 0 ? `across ${watched.length} videos` : undefined}
     >
       {watched.length > 0 ? (
-        <div className="mt-6 w-full max-w-2xl mx-auto space-y-2 max-h-[60vh] overflow-y-auto">
-          {watched.map((v, i) => {
-            const thumb = getThumb(v.url)
-            return (
-              <a
-                key={v.url}
-                href={v.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-3 p-3 rounded-xl bg-white/5 hover:bg-white/10 transition-colors"
-              >
-                <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 1}</span>
-                {thumb && (
-                  <div className="relative w-20 h-12 flex-shrink-0 rounded-lg overflow-hidden bg-white/10">
-                    <Image src={thumb} alt={v.title} fill className="object-cover" unoptimized />
+        <ScrollableList buttonLabel={`View all ${watched.length} videos`}>
+          <div className="space-y-2">
+            {watched.map((v, i) => {
+              const thumb = getThumb(v.url)
+              return (
+                <a
+                  key={v.url}
+                  href={v.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-3 p-3 rounded-xl bg-white/10 hover:bg-white/15 transition-colors"
+                >
+                  <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 1}</span>
+                  {thumb && (
+                    <div className="relative w-20 h-12 flex-shrink-0 rounded-lg overflow-hidden bg-white/10">
+                      <Image src={thumb} alt={v.title} fill className="object-cover" unoptimized />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0 text-left">
+                    <p className="text-sm text-white/90 font-medium line-clamp-2">{v.title}</p>
+                    <p className="text-xs text-white/40 mt-0.5">
+                      <span className="text-[#10B981] font-bold">{formatTime(v.watchSeconds)}</span>
+                      {v.timesWatched > 1 && <span> · {v.timesWatched}× played</span>}
+                    </p>
                   </div>
-                )}
-                <div className="flex-1 min-w-0 text-left">
-                  <p className="text-sm text-white/80 font-medium line-clamp-2">{v.title}</p>
-                  <p className="text-xs text-white/40 mt-0.5">
-                    <span className="text-[#10B981] font-bold">{formatTime(v.watchSeconds)}</span>
-                    {v.timesWatched > 1 && <span> · {v.timesWatched}× played</span>}
-                  </p>
-                </div>
-              </a>
-            )
-          })}
-        </div>
+                </a>
+              )
+            })}
+          </div>
+        </ScrollableList>
       ) : (
         <p className="mt-8 text-white/40">No watch data yet — browse YouTube to start tracking.</p>
       )}

--- a/components/scrollable-list.tsx
+++ b/components/scrollable-list.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useState } from "react"
+import { createPortal } from "react-dom"
+import { motion, AnimatePresence } from "framer-motion"
+
+interface ScrollableListProps {
+  children: React.ReactNode
+  buttonLabel?: string
+}
+
+export function ScrollableList({ children, buttonLabel = "View all" }: ScrollableListProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const overlay = (
+    <AnimatePresence>
+      {expanded && (
+        <>
+          {/* Blurred backdrop — fixed to viewport */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 backdrop-blur-xl bg-black/30"
+            onClick={() => setExpanded(false)}
+          />
+
+          {/* Panel — fixed size, always centered in viewport */}
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: "spring", stiffness: 120, damping: 20 }}
+            className="fixed z-50 inset-0 m-auto w-[calc(100%-2rem)] max-w-2xl h-[70vh] flex flex-col rounded-3xl bg-white/10 border border-white/15 backdrop-blur-md shadow-2xl overflow-hidden"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-3 border-b border-white/10 flex-shrink-0">
+              <span className="text-xs font-bold uppercase tracking-widest text-white/50">{buttonLabel}</span>
+              <button
+                onClick={() => setExpanded(false)}
+                className="px-3 py-1 rounded-full border border-white/15 bg-white/5 hover:bg-white/10 text-xs font-medium text-white/50 hover:text-white transition-colors"
+              >
+                Close
+              </button>
+            </div>
+
+            {/* Scrollable content */}
+            <div
+              className="flex-1 overflow-y-auto p-4"
+              style={{ scrollbarWidth: "thin", scrollbarColor: "rgba(255,255,255,0.15) transparent" }}
+            >
+              {children}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+
+  return (
+    <>
+      {!expanded && (
+        <motion.button
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4 }}
+          onClick={() => setExpanded(true)}
+          className="mt-4 px-6 py-2.5 rounded-full border border-white/20 bg-white/5 hover:bg-white/10 text-sm font-medium text-white/60 hover:text-white transition-colors"
+        >
+          {buttonLabel}
+        </motion.button>
+      )}
+
+      {typeof document !== "undefined" ? createPortal(overlay, document.body) : overlay}
+    </>
+  )
+}

--- a/components/slide-container.tsx
+++ b/components/slide-container.tsx
@@ -36,7 +36,7 @@ export function SlideContainer({ slides }: SlideContainerProps) {
         style={{ scrollbarWidth: "none" }}
       >
         {slides.map((slide, i) => (
-          <div key={i} className="snap-start flex-shrink-0 w-screen overflow-y-auto">
+          <div key={i} className="snap-start flex-shrink-0 w-screen overflow-hidden">
             {slide}
           </div>
         ))}

--- a/components/top-channels-slide.tsx
+++ b/components/top-channels-slide.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image"
 import { StatSlide } from "./stat-slide"
+import { ScrollableList } from "./scrollable-list"
 
 interface ChannelRow {
   channelName: string
@@ -20,34 +21,36 @@ export function TopChannelsSlide({ channels, gradient }: { channels: ChannelRow[
       subtext={channels.length > 0 ? `${channels[0].videoCount} videos recommended` : undefined}
     >
       {channels.length > 1 ? (
-        <div className="mt-6 w-full max-w-2xl mx-auto space-y-2 max-h-[55vh] overflow-y-auto">
-          {channels.slice(1, 15).map((ch, i) => (
-            <a
-              key={ch.channelName}
-              href={ch.channelUrl ?? `https://www.youtube.com/results?search_query=${encodeURIComponent(ch.channelName)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-3 p-3 rounded-xl bg-white/5 hover:bg-white/10 transition-colors"
-            >
-              <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 2}</span>
-              {ch.channelAvatarUrl ? (
-                <div className="relative w-8 h-8 flex-shrink-0 rounded-full overflow-hidden bg-white/10">
-                  <Image src={ch.channelAvatarUrl} alt="" fill className="object-cover" unoptimized />
+        <ScrollableList buttonLabel={`View all ${channels.length} channels`}>
+          <div className="space-y-2">
+            {channels.map((ch, i) => (
+              <a
+                key={ch.channelName}
+                href={ch.channelUrl ?? `https://www.youtube.com/results?search_query=${encodeURIComponent(ch.channelName)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-3 p-3 rounded-xl bg-white/10 hover:bg-white/15 transition-colors"
+              >
+                <span className="text-white/30 font-mono text-sm w-6 text-right flex-shrink-0">{i + 1}</span>
+                {ch.channelAvatarUrl ? (
+                  <div className="relative w-8 h-8 flex-shrink-0 rounded-full overflow-hidden bg-white/10">
+                    <Image src={ch.channelAvatarUrl} alt="" fill className="object-cover" unoptimized />
+                  </div>
+                ) : (
+                  <div className="w-8 h-8 flex-shrink-0 rounded-full bg-white/10 flex items-center justify-center text-white/30 text-xs font-bold">
+                    {ch.channelName[0]}
+                  </div>
+                )}
+                <div className="flex-1 min-w-0 text-left">
+                  <p className="text-sm text-white/90 font-medium">{ch.channelName}</p>
+                  <p className="text-xs text-white/40 mt-0.5">
+                    {ch.videoCount} videos · seen {ch.totalSeen}×
+                  </p>
                 </div>
-              ) : (
-                <div className="w-8 h-8 flex-shrink-0 rounded-full bg-white/10 flex items-center justify-center text-white/30 text-xs font-bold">
-                  {ch.channelName[0]}
-                </div>
-              )}
-              <div className="flex-1 min-w-0 text-left">
-                <p className="text-sm text-white/80 font-medium">{ch.channelName}</p>
-                <p className="text-xs text-white/40 mt-0.5">
-                  {ch.videoCount} videos · seen {ch.totalSeen}×
-                </p>
-              </div>
-            </a>
-          ))}
-        </div>
+              </a>
+            ))}
+          </div>
+        </ScrollableList>
       ) : channels.length === 0 ? (
         <p className="mt-8 text-white/40">No channel data yet — browse YouTube to start tracking.</p>
       ) : null}


### PR DESCRIPTION
Slides no longer scroll — overflow is hidden. Lists are accessed via a "View all" button that opens a fixed viewport overlay (portaled to body) with backdrop-blur, frosted glass panel, and scrollable content. All list overlays share the same size (max-w-2xl, 70vh). Bumped list item contrast for better readability.