### PR TITLE
perf: Scope videos, words, and channels queries by date/month

### DIFF
--- a/app/api/users/[username]/stats/channels/route.ts
+++ b/app/api/users/[username]/stats/channels/route.ts
@@ -1,6 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { getDb, videos } from "@/lib/db"
-import { eq, sql, isNotNull, and } from "drizzle-orm"
+import { getDb, videos, userVideoStats } from "@/lib/db"
+import { eq, sql, isNotNull, and, like } from "drizzle-orm"
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -13,14 +13,45 @@ export function OPTIONS() {
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ username: string }> }
 ) {
   try {
     const { username } = await params
     const { env } = getCloudflareContext()
     const db = getDb(env.DB)
+    const url = new URL(request.url)
+    const date = url.searchParams.get("date")
+    const month = url.searchParams.get("month")
 
+    if (date || month) {
+      // Scoped: join through userVideoStats for date filtering
+      const dateFilter = date
+        ? eq(userVideoStats.date, date)
+        : like(userVideoStats.date, `${month}%`)
+
+      const rows = await db
+        .select({
+          channelName: videos.channelName,
+          channelUrl: videos.channelUrl,
+          channelAvatarUrl: sql<string | null>`MAX(${videos.channelAvatarUrl})`,
+          videoCount: sql<number>`COUNT(DISTINCT ${videos.url})`,
+          totalSeen: sql<number>`SUM(CASE WHEN ${userVideoStats.source} != 'watched' THEN ${userVideoStats.timesSeen} ELSE 0 END)`,
+          totalWatched: sql<number>`SUM(CASE WHEN ${userVideoStats.source} = 'watched' THEN ${userVideoStats.timesWatched} ELSE 0 END)`,
+          totalWatchSeconds: sql<number>`SUM(${userVideoStats.watchSeconds})`,
+        })
+        .from(userVideoStats)
+        .innerJoin(videos, eq(userVideoStats.videoUrl, videos.url))
+        .where(and(eq(userVideoStats.username, username), dateFilter, isNotNull(videos.channelName)))
+        .groupBy(videos.channelName)
+        .orderBy(sql`COUNT(DISTINCT ${videos.url}) DESC`)
+        .limit(30)
+        .all()
+
+      return Response.json(rows, { headers: CORS })
+    }
+
+    // All-time: query videos table directly
     const rows = await db
       .select({
         channelName: videos.channelName,

--- a/app/api/users/[username]/videos/route.ts
+++ b/app/api/users/[username]/videos/route.ts
@@ -1,7 +1,6 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { getDb, videos } from "@/lib/db"
-import { eq } from "drizzle-orm"
-
+import { getDb, videos, userVideoStats } from "@/lib/db"
+import { eq, and, sql, like } from "drizzle-orm"
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -14,13 +13,45 @@ export function OPTIONS() {
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ username: string }> }
 ) {
   try {
     const { username } = await params
     const { env } = getCloudflareContext()
     const db = getDb(env.DB)
+    const url = new URL(request.url)
+    const date = url.searchParams.get("date")    // exact date YYYY-MM-DD
+    const month = url.searchParams.get("month")  // month prefix YYYY-MM
+
+    if (date || month) {
+      // Scoped query: join userVideoStats for date filtering, aggregate stats
+      const dateFilter = date
+        ? eq(userVideoStats.date, date)
+        : like(userVideoStats.date, `${month}%`)
+
+      const rows = await db
+        .select({
+          url: videos.url,
+          title: videos.title,
+          imageUrl: videos.imageUrl,
+          username: videos.username,
+          channelName: videos.channelName,
+          channelUrl: videos.channelUrl,
+          timesWatched: sql<number>`SUM(CASE WHEN ${userVideoStats.source} = 'watched' THEN ${userVideoStats.timesWatched} ELSE 0 END)`,
+          timesSeen: sql<number>`SUM(CASE WHEN ${userVideoStats.source} != 'watched' THEN ${userVideoStats.timesSeen} ELSE 0 END)`,
+          watchSeconds: sql<number>`SUM(${userVideoStats.watchSeconds})`,
+        })
+        .from(userVideoStats)
+        .innerJoin(videos, eq(userVideoStats.videoUrl, videos.url))
+        .where(and(eq(userVideoStats.username, username), dateFilter))
+        .groupBy(videos.url)
+        .all()
+
+      return Response.json(rows, { headers: CORS })
+    }
+
+    // All-time: return directly from videos table
     const results = await db.select().from(videos).where(eq(videos.username, username)).all()
     return Response.json(results, { headers: CORS })
   } catch (err) {

--- a/app/api/users/[username]/words/route.ts
+++ b/app/api/users/[username]/words/route.ts
@@ -1,8 +1,7 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare"
-import { getDb, words, videos } from "@/lib/db"
-import { eq, desc } from "drizzle-orm"
+import { getDb, words, userVideoStats } from "@/lib/db"
+import { eq, and, desc, like, sql } from "drizzle-orm"
 import type { WordsResponse } from "@/lib/types"
-
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -24,41 +23,77 @@ export async function GET(
     const db = getDb(env.DB)
     const { searchParams } = new URL(request.url)
     const date = searchParams.get("date")
-    const month = searchParams.get("month") // YYYY-MM
+    const month = searchParams.get("month")
     const limit = parseInt(searchParams.get("limit") ?? "100")
 
-    const allWords = await db
-      .select()
-      .from(words)
-      .where(eq(words.username, username))
-      .orderBy(desc(words.timesSeen))
-      .all()
+    // Build where conditions for words
+    const conditions = [eq(words.username, username)]
+    if (date) conditions.push(eq(words.date, date))
+    else if (month) conditions.push(like(words.date, `${month}%`))
 
-    const filtered = allWords
-      .filter(w => {
-        if (date) return w.date === date
-        if (month) return w.date.startsWith(month)
-        return true
+    // When date-scoped, aggregate across days (same word on different days = summed)
+    // When not scoped, still aggregate since words table has one row per (text, date, username)
+    const wordRows = await db
+      .select({
+        text: words.text,
+        date: date ? words.date : sql<string>`MIN(${words.date})`,
+        username: words.username,
+        videoUrls: sql<string>`'[' || GROUP_CONCAT(DISTINCT REPLACE(REPLACE(${words.videoUrls}, '[', ''), ']', '')) || ']'`,
+        timesWatched: sql<number>`SUM(${words.timesWatched})`,
+        timesSeen: sql<number>`SUM(${words.timesSeen})`,
       })
-      .slice(0, limit)
-
-    const totalVideos = await db
-      .select()
-      .from(videos)
-      .where(eq(videos.username, username))
+      .from(words)
+      .where(and(...conditions))
+      .groupBy(words.text)
+      .orderBy(desc(sql`SUM(${words.timesSeen})`))
+      .limit(limit)
       .all()
 
-    const wordData = filtered.map(w => ({
-      text: w.text,
-      date: w.date,
-      username: w.username,
-      videoUrls: JSON.parse(w.videoUrls) as string[],
-      timesWatched: w.timesWatched,
-      timesSeen: w.timesSeen,
-    }))
+    // Video count — use userVideoStats for date-scoped count, otherwise count distinct URLs
+    let totalVideos: number
+    if (date || month) {
+      const dateFilter = date
+        ? eq(userVideoStats.date, date)
+        : like(userVideoStats.date, `${month}%`)
+      const [row] = await db
+        .select({ count: sql<number>`COUNT(DISTINCT ${userVideoStats.videoUrl})` })
+        .from(userVideoStats)
+        .where(and(eq(userVideoStats.username, username), dateFilter))
+        .all()
+      totalVideos = row?.count ?? 0
+    } else {
+      const [row] = await db
+        .select({ count: sql<number>`COUNT(DISTINCT ${userVideoStats.videoUrl})` })
+        .from(userVideoStats)
+        .where(eq(userVideoStats.username, username))
+        .all()
+      totalVideos = row?.count ?? 0
+    }
+
+    // Parse the concatenated videoUrls back into arrays
+    const wordData = wordRows.map(w => {
+      let urls: string[] = []
+      try {
+        // GROUP_CONCAT produces: ["url1","url2","url3"] but with possible quotes
+        const raw = w.videoUrls as string
+        // Split the inner content and dedupe
+        const inner = raw.replace(/^\[/, "").replace(/\]$/, "")
+        urls = inner
+          ? Array.from(new Set(inner.split(",").map(s => s.trim().replace(/^"|"$/g, "")).filter(Boolean)))
+          : []
+      } catch {}
+      return {
+        text: w.text,
+        date: w.date,
+        username: w.username,
+        videoUrls: urls,
+        timesWatched: w.timesWatched,
+        timesSeen: w.timesSeen,
+      }
+    })
 
     const response: WordsResponse = {
-      videoMetrics: { totalVideos: totalVideos.length },
+      videoMetrics: { totalVideos },
       wordData,
     }
 

--- a/app/daily/page.tsx
+++ b/app/daily/page.tsx
@@ -29,14 +29,14 @@ export default function DailyPage() {
   })
 
   const { data: videosData } = useQuery<Video[]>({
-    queryKey: ["videos", username],
-    queryFn: () => fetch(`/api/users/${username}/videos`).then(r => r.json()),
+    queryKey: ["videos", "daily", TODAY, username],
+    queryFn: () => fetch(apiRoutes.userVideos(username!, { date: TODAY })).then(r => r.json()),
     enabled: !!username,
   })
 
   const { data: channelsData } = useQuery<any[]>({
-    queryKey: ["channels", username],
-    queryFn: () => fetch(apiRoutes.userStatsChannels(username!)).then(r => r.json()),
+    queryKey: ["channels", "daily", TODAY, username],
+    queryFn: () => fetch(apiRoutes.userStatsChannels(username!, { date: TODAY })).then(r => r.json()),
     enabled: !!username,
     select: (d) => (Array.isArray(d) ? d : []),
   })

--- a/app/wrapped/page.tsx
+++ b/app/wrapped/page.tsx
@@ -24,15 +24,15 @@ export default function WrappedPage() {
   })
 
   const { data: videosData } = useQuery<Video[]>({
-    queryKey: ["videos", username],
-    queryFn: () => fetch(`/api/users/${username}/videos`).then(r => r.json()),
+    queryKey: ["videos", "month", MONTH_KEY, username],
+    queryFn: () => fetch(apiRoutes.userVideos(username!, { month: MONTH_KEY })).then(r => r.json()),
     enabled: !!username,
     select: (data) => (Array.isArray(data) ? data : []),
   })
 
   const { data: channelsData } = useQuery<any[]>({
-    queryKey: ["channels", username],
-    queryFn: () => fetch(apiRoutes.userStatsChannels(username!)).then(r => r.json()),
+    queryKey: ["channels", "month", MONTH_KEY, username],
+    queryFn: () => fetch(apiRoutes.userStatsChannels(username!, { month: MONTH_KEY })).then(r => r.json()),
     enabled: !!username,
     select: (d) => (Array.isArray(d) ? d : []),
   })

--- a/lib/api-routes.ts
+++ b/lib/api-routes.ts
@@ -12,7 +12,13 @@ export const apiRoutes = {
   user: (username: string) => `/api/users/${username}`,
 
   // Per-user resources
-  userVideos: (username: string) => `/api/users/${username}/videos`,
+  userVideos: (username: string, params?: { date?: string; month?: string }) => {
+    const q = new URLSearchParams()
+    if (params?.date) q.set("date", params.date)
+    if (params?.month) q.set("month", params.month)
+    const qs = q.toString()
+    return `/api/users/${username}/videos${qs ? `?${qs}` : ""}`
+  },
   userWords: (username: string, params?: { date?: string; month?: string; limit?: number }) => {
     const q = new URLSearchParams()
     if (params?.date) q.set("date", params.date)
@@ -31,8 +37,13 @@ export const apiRoutes = {
     `/api/users/${username}/stats/word-trends?top=${top}`,
   userStatsSourceDistribution: (username: string) =>
     `/api/users/${username}/stats/source-distribution`,
-  userStatsChannels: (username: string) =>
-    `/api/users/${username}/stats/channels`,
+  userStatsChannels: (username: string, params?: { date?: string; month?: string }) => {
+    const q = new URLSearchParams()
+    if (params?.date) q.set("date", params.date)
+    if (params?.month) q.set("month", params.month)
+    const qs = q.toString()
+    return `/api/users/${username}/stats/channels${qs ? `?${qs}` : ""}`
+  },
   userStatsRecommendationGraph: (username: string) =>
     `/api/users/${username}/stats/recommendation-graph`,
 


### PR DESCRIPTION
Videos, words, and channels endpoints now accept ?date= and ?month= params that filter via userVideoStats joins instead of fetching everything into memory. Words endpoint rewrites: filtering, aggregation, counting, and limiting all done in SQL. Daily page passes today's date, wrapped passes the current month, all-time remains unscoped.